### PR TITLE
Ometif fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM continuumio/miniconda3
+FROM continuumio/miniconda3:4.5.12
 
 RUN apt-get update && apt-get install -y gcc openjdk-8-jdk && rm -rf /var/lib/apt/lists/*
 RUN conda install cython boto3 scikit-image
-RUN pip install -q pyjnius
-RUN curl -o /opt/loci_tools.jar http://downloads.openmicroscopy.org/bio-formats/5.8.2/artifacts/loci_tools.jar
+RUN pip install -q pyjnius==1.2.1
+RUN curl -o /opt/loci_tools.jar https://downloads.openmicroscopy.org/bio-formats/5.8.2/artifacts/loci_tools.jar
 
 COPY bfextractor.py /opt
 


### PR DESCRIPTION
Fixes related to ome.tif import not working, mostly pyjnius usage.  
  
Also froze miniconda3 base image to older version, because newest image does not offer openjdk-8-jdk in default repositories. Bioformats url has changed from http to https.